### PR TITLE
Auto attach sources for Scala libraries

### DIFF
--- a/java/src/com/google/idea/blaze/java/libraries/BlazeAttachSourceProvider.java
+++ b/java/src/com/google/idea/blaze/java/libraries/BlazeAttachSourceProvider.java
@@ -51,6 +51,19 @@ public class BlazeAttachSourceProvider implements AttachSourcesProvider {
   private static final BoolExperiment attachAutomatically =
       new BoolExperiment("blaze.attach.source.jars.automatically.2", true);
 
+  private final BlazeJarLibraryLocator blazeJarLibraryLocator;
+
+  /**
+   * Used by the intellij platform to construct an BlazeAttachSourceProvider for Java
+   */
+  public BlazeAttachSourceProvider() {
+    this.blazeJarLibraryLocator = new BlazeJavaJarLibraryLocator();
+  }
+
+  public BlazeAttachSourceProvider(BlazeJarLibraryLocator blazeJarLibraryLocator) {
+    this.blazeJarLibraryLocator = blazeJarLibraryLocator;
+  }
+
   @Override
   public Collection<AttachSourcesAction> getActions(
       List<LibraryOrderEntry> orderEntries, final PsiFile psiFile) {
@@ -76,7 +89,7 @@ public class BlazeAttachSourceProvider implements AttachSourcesProvider {
         continue;
       }
       BlazeJarLibrary blazeLibrary =
-          LibraryActionHelper.findLibraryFromIntellijLibrary(project, blazeProjectData, library);
+              blazeJarLibraryLocator.findLibraryFromIntellijLibrary(project, blazeProjectData, library);
       if (blazeLibrary == null) {
         continue;
       }

--- a/java/src/com/google/idea/blaze/java/libraries/BlazeJarLibraryLocator.java
+++ b/java/src/com/google/idea/blaze/java/libraries/BlazeJarLibraryLocator.java
@@ -1,0 +1,10 @@
+package com.google.idea.blaze.java.libraries;
+
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.java.sync.model.BlazeJarLibrary;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.libraries.Library;
+
+public interface BlazeJarLibraryLocator {
+  BlazeJarLibrary findLibraryFromIntellijLibrary(Project project, BlazeProjectData blazeProjectData, Library library);
+}

--- a/java/src/com/google/idea/blaze/java/libraries/BlazeJavaJarLibraryLocator.java
+++ b/java/src/com/google/idea/blaze/java/libraries/BlazeJavaJarLibraryLocator.java
@@ -1,0 +1,14 @@
+package com.google.idea.blaze.java.libraries;
+
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.java.sync.model.BlazeJarLibrary;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.libraries.Library;
+
+class BlazeJavaJarLibraryLocator implements BlazeJarLibraryLocator {
+
+  @Override
+  public BlazeJarLibrary findLibraryFromIntellijLibrary(Project project, BlazeProjectData blazeProjectData, Library library) {
+    return LibraryActionHelper.findLibraryFromIntellijLibrary(project, blazeProjectData, library);
+  }
+}

--- a/scala/src/META-INF/scala-contents.xml
+++ b/scala/src/META-INF/scala-contents.xml
@@ -45,6 +45,7 @@
         order="first"/>
     <stepsBeforeRunProvider
         implementation="com.google.idea.blaze.scala.run.producers.GenerateDeployableJarTaskProvider"/>
+    <attachSourcesProvider implementation="com.google.idea.blaze.scala.libraries.BlazeScalaAttachSourceProvider"/>
   </extensions>
 
   <project-components>

--- a/scala/src/com/google/idea/blaze/scala/libraries/BlazeScalaAttachSourceProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/libraries/BlazeScalaAttachSourceProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.scala.libraries;
+
+import com.google.idea.blaze.java.libraries.BlazeAttachSourceProvider;
+import com.intellij.codeInsight.AttachSourcesProvider;
+import com.intellij.openapi.roots.LibraryOrderEntry;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Adapts {@link BlazeAttachSourceProvider} to Scala libraries.
+ *
+ * @see BlazeAttachSourceProvider
+ */
+public class BlazeScalaAttachSourceProvider implements AttachSourcesProvider {
+
+  private final AttachSourcesProvider delegate = new BlazeAttachSourceProvider(new BlazeScalaJarLibraryLocator());
+
+  @NotNull
+  @Override
+  public Collection<AttachSourcesAction> getActions(List<LibraryOrderEntry> list, PsiFile psiFile) {
+    return delegate.getActions(list, psiFile);
+  }
+}

--- a/scala/src/com/google/idea/blaze/scala/libraries/BlazeScalaJarLibraryLocator.java
+++ b/scala/src/com/google/idea/blaze/scala/libraries/BlazeScalaJarLibraryLocator.java
@@ -1,0 +1,30 @@
+package com.google.idea.blaze.scala.libraries;
+
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.model.LibraryKey;
+import com.google.idea.blaze.java.libraries.BlazeJarLibraryLocator;
+import com.google.idea.blaze.java.sync.model.BlazeJarLibrary;
+import com.google.idea.blaze.scala.sync.model.BlazeScalaSyncData;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.libraries.Library;
+import com.intellij.openapi.ui.Messages;
+
+class BlazeScalaJarLibraryLocator implements BlazeJarLibraryLocator {
+
+  @Override
+  public BlazeJarLibrary findLibraryFromIntellijLibrary(
+          Project project, BlazeProjectData blazeProjectData, Library library) {
+
+    String libName = library.getName();
+    if (libName == null) {
+      return null;
+    }
+    LibraryKey libraryKey = LibraryKey.fromIntelliJLibraryName(libName);
+    BlazeScalaSyncData syncData = blazeProjectData.getSyncState().get(BlazeScalaSyncData.class);
+    if (syncData == null) {
+      Messages.showErrorDialog(project, "Project isn't synced. Please resync project.", "Error");
+      return null;
+    }
+    return syncData.getImportResult().libraries.get(libraryKey);
+  }
+}


### PR DESCRIPTION
This PR adds an implementation of `AttachSourcesProvider` for Scala libraries.
The new implementation reuses all the existing code written for Java in `BlazeAttachSourceProvider` and uses a new abstraction, that takes care of locating the library information from the Scala libraries model.
This takes care of automatic source attachment, when a user navigates to a third-party library that has a source-jar. Whether or not a source-jar exists is a matter of how the library is imported in the Bazel build files.

The implementation of `findLibraryFromIntellijLibrary` is pretty much copied, except for the part that queries for the Scala specific sync-data object. That can change of course, but it requires, refactoring in other areas I prefer to avoid, at least until I discuss this change further with the plugin maintainers.

Tested manually and verified the desired behaviour in the (amazing Java) debugger. **No idea how to approach testing this** at the moment, if at all..

I will appreciate any feedback you might have.