### PR TITLE
changed library key to a stronger hash (SHA1) to avoid potential 'Str…

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/LibraryKey.java
+++ b/base/src/com/google/idea/blaze/base/model/LibraryKey.java
@@ -15,10 +15,12 @@
  */
 package com.google.idea.blaze.base.model;
 
+import com.google.common.hash.Hashing;
 import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
 import com.google.idea.blaze.base.ideinfo.ProtoWrapper;
 import com.intellij.openapi.util.io.FileUtil;
 import java.io.File;
+import java.nio.charset.Charset;
 import javax.annotation.concurrent.Immutable;
 
 /** Uniquely identifies a library as imported into IntellJ. */
@@ -32,9 +34,8 @@ public final class LibraryKey implements ProtoWrapper<String> {
 
   public static String libraryNameFromArtifactLocation(ArtifactLocation artifactLocation) {
     File file = new File(artifactLocation.getExecutionRootRelativePath());
-    String parent = file.getParent();
-    int parentHash = parent != null ? parent.hashCode() : file.hashCode();
-    return FileUtil.getNameWithoutExtension(file) + "_" + Integer.toHexString(parentHash);
+    String hash = Hashing.sha1().hashString(file.getAbsolutePath(), Charset.forName("UTF-8")).toString();
+    return FileUtil.getNameWithoutExtension(file) + "_" + hash;
   }
 
   public static LibraryKey forResourceLibrary() {


### PR DESCRIPTION
This PR fixes a potential problem in intellij library names. The current algorithm that generates library keys (which also serves as library names at the moment) might cause clashes, since it relies on `String.hashCode()` which isn't designed to generate unique codes.

@or-shachar I want to merge this and release internally, to try and see whether it solves real problem for us, since there are many libraries with equal names in our workspaces.
