### PR TITLE
Revert "changed library key to a stronger hash (SHA1) to avoid potent…

### DIFF
--- a/base/src/com/google/idea/blaze/base/model/LibraryKey.java
+++ b/base/src/com/google/idea/blaze/base/model/LibraryKey.java
@@ -15,12 +15,10 @@
  */
 package com.google.idea.blaze.base.model;
 
-import com.google.common.hash.Hashing;
 import com.google.idea.blaze.base.ideinfo.ArtifactLocation;
 import com.google.idea.blaze.base.ideinfo.ProtoWrapper;
 import com.intellij.openapi.util.io.FileUtil;
 import java.io.File;
-import java.nio.charset.Charset;
 import javax.annotation.concurrent.Immutable;
 
 /** Uniquely identifies a library as imported into IntellJ. */
@@ -34,8 +32,9 @@ public final class LibraryKey implements ProtoWrapper<String> {
 
   public static String libraryNameFromArtifactLocation(ArtifactLocation artifactLocation) {
     File file = new File(artifactLocation.getExecutionRootRelativePath());
-    String hash = Hashing.sha1().hashString(file.getAbsolutePath(), Charset.forName("UTF-8")).toString();
-    return FileUtil.getNameWithoutExtension(file) + "_" + hash;
+    String parent = file.getParent();
+    int parentHash = parent != null ? parent.hashCode() : file.hashCode();
+    return FileUtil.getNameWithoutExtension(file) + "_" + Integer.toHexString(parentHash);
   }
 
   public static LibraryKey forResourceLibrary() {


### PR DESCRIPTION
Reverting my change to the library naming algorithm after some people complained about intellij freezing issues. Will probably restore this behaviour later when the current issues are resolved..