### PR TITLE
Add option to show workspace root file excluding sub directories

### DIFF
--- a/base/src/com/google/idea/blaze/base/settings/BlazeUserSettings.java
+++ b/base/src/com/google/idea/blaze/base/settings/BlazeUserSettings.java
@@ -74,6 +74,7 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
   private boolean collapseProjectView = true;
   private boolean formatBuildFilesOnSave = true;
   private boolean showAddFileToProjectNotification = true;
+  private boolean showRootFiles = false;
   private boolean enableBazelIgnore = true;
   private String blazeBinaryPath = DEFAULT_BLAZE_PATH;
   private String bazelBinaryPath = DEFAULT_BAZEL_PATH;
@@ -242,6 +243,16 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
 
   public void setEnableBazelIgnore(boolean enableBazelIgnore) {
     this.enableBazelIgnore = enableBazelIgnore;
+
+    // TODO trigger refresh
+  }
+
+  public boolean getShowRootFiles() {
+    return showRootFiles;
+  }
+
+  public void setShowRootFiles(boolean showRootFiles) {
+    this.showRootFiles = showRootFiles;
 
     // TODO trigger refresh
   }

--- a/base/src/com/google/idea/blaze/base/settings/ui/BlazeUserSettingsConfigurable.java
+++ b/base/src/com/google/idea/blaze/base/settings/ui/BlazeUserSettingsConfigurable.java
@@ -121,6 +121,12 @@ public class BlazeUserSettingsConfigurable extends AutoConfigurable {
                   .setter(BlazeUserSettings::setEnableBazelIgnore)
                   .componentFactory(SimpleComponent::createCheckBox);
 
+  public static final ConfigurableSetting<?, ?> SHOW_ROOT_FILES =
+          setting("With multiple entries . exludes workspace root directories")
+                  .getter(BlazeUserSettings::getShowRootFiles)
+                  .setter(BlazeUserSettings::setShowRootFiles)
+                  .componentFactory(SimpleComponent::createCheckBox);
+
   private static final String BLAZE_BINARY_PATH_KEY = "blaze.binary.path";
   private static final ConfigurableSetting<?, ?> BLAZE_BINARY_PATH =
       setting("Blaze binary location")
@@ -147,6 +153,7 @@ public class BlazeUserSettingsConfigurable extends AutoConfigurable {
           FORMAT_BUILD_FILES_ON_SAVE,
           SHOW_ADD_FILE_TO_PROJECT,
           ENABLE_BAZEL_IGNORE,
+          SHOW_ROOT_FILES,
           BLAZE_BINARY_PATH,
           BAZEL_BINARY_PATH);
 
@@ -175,6 +182,7 @@ public class BlazeUserSettingsConfigurable extends AutoConfigurable {
             FORMAT_BUILD_FILES_ON_SAVE,
             SHOW_ADD_FILE_TO_PROJECT,
             ENABLE_BAZEL_IGNORE,
+            SHOW_ROOT_FILES,
             BLAZE_BINARY_PATH,
             BAZEL_BINARY_PATH));
   }


### PR DESCRIPTION
Allows to see workspace root files excluding subfolders. Requested by @mvaitkus. By default this feature is off, can be enable in `Settings -> Other -> Bazel -> With multiple entries . excludes workspace root directories`.
This feature is allows to access workspace file like `.bazelignore` and others, without a need to include full directory tree.
State: experimental

Example: when enabled, and '.' is added to the directories list, all unlisted top level directories are excluded.
```
directories:
  membership
  third_party
  members-area
  badges
  tools
  .
```