### PR TITLE
Add test search scope to the project if it contains test targets inde…

### DIFF
--- a/base/src/META-INF/blaze-base.xml
+++ b/base/src/META-INF/blaze-base.xml
@@ -285,6 +285,10 @@
     <lang.documentationProvider language="projectview" implementationClass="com.google.idea.blaze.base.lang.projectview.documentation.ProjectViewDocumentationProvider"/>
     <langCodeStyleSettingsProvider implementation="com.google.idea.blaze.base.lang.projectview.formatting.ProjectViewCodeStyleSettingsProvider"/>
     <lang.rearranger language="projectview" implementationClass="com.google.idea.blaze.base.lang.projectview.formatting.ProjectViewRearranger"/>
+    <testSourcesFilter implementation="com.google.idea.blaze.base.search.BazelTestSourcesFilter"/>
+    <applicationService serviceInterface="com.intellij.psi.search.PredefinedSearchScopeProvider"
+                        serviceImplementation="com.google.idea.blaze.base.search.BazelOptionalTestScopeSearchProvider"
+                        overrides="true"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/base/src/com/google/idea/blaze/base/search/BazelOptionalTestScopeSearchProvider.java
+++ b/base/src/com/google/idea/blaze/base/search/BazelOptionalTestScopeSearchProvider.java
@@ -1,0 +1,45 @@
+package com.google.idea.blaze.base.search;
+
+import com.google.idea.blaze.base.model.BlazeProjectData;
+import com.google.idea.blaze.base.sync.data.BlazeProjectDataManager;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.GlobalSearchScopesCore;
+import com.intellij.psi.search.PredefinedSearchScopeProviderImpl;
+import com.intellij.psi.search.SearchScope;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+public class BazelOptionalTestScopeSearchProvider extends PredefinedSearchScopeProviderImpl {
+
+	@Override
+	public List<SearchScope> getPredefinedScopes(@NotNull Project project, @Nullable DataContext dataContext,
+	                                             boolean suggestSearchInLibs, boolean prevSearchFiles,
+	                                             boolean currentSelection, boolean usageView, boolean showEmptyScopes) {
+		List<SearchScope> predefinedScopes = super.getPredefinedScopes(project, dataContext, suggestSearchInLibs, prevSearchFiles, currentSelection, usageView, showEmptyScopes);
+
+		BlazeProjectData projectData =
+				BlazeProjectDataManager.getInstance(project).getBlazeProjectData();
+
+		boolean hasTestTargets = Optional.ofNullable(projectData)
+				.map(data -> data
+						.getTargetMap()
+						.targets()
+						.stream()
+						.anyMatch(targetIdeInfo -> targetIdeInfo.getKind().getKindString().endsWith("_test"))
+				).orElse(false);
+		if (hasTestTargets) {
+			int index = predefinedScopes.indexOf(GlobalSearchScope.projectScope(project));
+			index = index == -1 ? 2 : index; // just leave both scopes at the top of the list
+
+			predefinedScopes.add(index + 1, GlobalSearchScopesCore.projectProductionScope(project));
+			predefinedScopes.add(index + 2, GlobalSearchScopesCore.projectTestScope(project));
+		}
+
+		return predefinedScopes;
+	}
+}

--- a/base/src/com/google/idea/blaze/base/search/BazelTestSourcesFilter.java
+++ b/base/src/com/google/idea/blaze/base/search/BazelTestSourcesFilter.java
@@ -1,0 +1,27 @@
+package com.google.idea.blaze.base.search;
+
+import com.google.common.collect.ImmutableList;
+import com.google.idea.blaze.base.model.primitives.Label;
+import com.google.idea.blaze.base.run.targetfinder.TargetFinder;
+import com.google.idea.blaze.base.targetmaps.SourceToTargetMap;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.TestSourcesFilter;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class BazelTestSourcesFilter extends TestSourcesFilter {
+
+	@Override
+	public boolean isTestSource(@NotNull VirtualFile file, @NotNull Project project) {
+		ImmutableList<Label> targetsToBuildForSourceFile = SourceToTargetMap.getInstance(project)
+				.getTargetsToBuildForSourceFile(VfsUtilCore.virtualToIoFile(file));
+		if (!targetsToBuildForSourceFile.isEmpty()) {
+			return Objects.requireNonNull(TargetFinder.findTargetInfo(project, targetsToBuildForSourceFile.get(0))).kindString.endsWith("_test");
+		} else {
+			return false;
+		}
+	}
+}

--- a/base/src/com/google/idea/blaze/base/settings/BlazeUserSettings.java
+++ b/base/src/com/google/idea/blaze/base/settings/BlazeUserSettings.java
@@ -74,6 +74,7 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
   private boolean collapseProjectView = true;
   private boolean formatBuildFilesOnSave = true;
   private boolean showAddFileToProjectNotification = true;
+  private boolean enableBazelIgnore = true;
   private String blazeBinaryPath = DEFAULT_BLAZE_PATH;
   private String bazelBinaryPath = DEFAULT_BAZEL_PATH;
 
@@ -235,6 +236,16 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
     }
   }
 
+  public boolean getEnableBazelIgnore() {
+    return enableBazelIgnore;
+  }
+
+  public void setEnableBazelIgnore(boolean enableBazelIgnore) {
+    this.enableBazelIgnore = enableBazelIgnore;
+
+    // TODO trigger refresh
+  }
+
   static class SettingsLogger implements LoggedSettingsProvider {
 
     @Override
@@ -260,6 +271,7 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
           Boolean.toString(settings.showAddFileToProjectNotification));
       builder.put("blazeBinaryPath", settings.blazeBinaryPath);
       builder.put("bazelBinaryPath", settings.bazelBinaryPath);
+      builder.put("enableBazelIgnore", Boolean.toString(settings.enableBazelIgnore));
       return builder.build();
     }
   }

--- a/base/src/com/google/idea/blaze/base/settings/BlazeUserSettings.java
+++ b/base/src/com/google/idea/blaze/base/settings/BlazeUserSettings.java
@@ -74,6 +74,7 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
   private boolean collapseProjectView = true;
   private boolean formatBuildFilesOnSave = true;
   private boolean showAddFileToProjectNotification = true;
+  private boolean showRootFiles = false;
   private boolean enableBazelIgnore = true;
   private String blazeBinaryPath = DEFAULT_BLAZE_PATH;
   private String bazelBinaryPath = DEFAULT_BAZEL_PATH;
@@ -242,6 +243,16 @@ public class BlazeUserSettings implements PersistentStateComponent<BlazeUserSett
 
   public void setEnableBazelIgnore(boolean enableBazelIgnore) {
     this.enableBazelIgnore = enableBazelIgnore;
+
+    // TODO trigger refresh
+  }
+
+  public boolean getShowRootFiles() {
+    return showRootFiles;
+  }
+
+  public void setShowRootFiles(boolean showRootFiles) {
+    this.showRootFiles = showRootFiles;
 
     // TODO trigger refresh
   }

--- a/base/src/com/google/idea/blaze/base/settings/ui/BlazeUserSettingsConfigurable.java
+++ b/base/src/com/google/idea/blaze/base/settings/ui/BlazeUserSettingsConfigurable.java
@@ -115,6 +115,12 @@ public class BlazeUserSettingsConfigurable extends AutoConfigurable {
           .setter(BlazeUserSettings::setShowAddFileToProjectNotification)
           .componentFactory(SimpleComponent::createCheckBox);
 
+  public static final ConfigurableSetting<?, ?> ENABLE_BAZEL_IGNORE =
+          setting("Enable .bazelignore exclusions")
+                  .getter(BlazeUserSettings::getEnableBazelIgnore)
+                  .setter(BlazeUserSettings::setEnableBazelIgnore)
+                  .componentFactory(SimpleComponent::createCheckBox);
+
   private static final String BLAZE_BINARY_PATH_KEY = "blaze.binary.path";
   private static final ConfigurableSetting<?, ?> BLAZE_BINARY_PATH =
       setting("Blaze binary location")
@@ -140,6 +146,7 @@ public class BlazeUserSettingsConfigurable extends AutoConfigurable {
           COLLAPSE_PROJECT_VIEW,
           FORMAT_BUILD_FILES_ON_SAVE,
           SHOW_ADD_FILE_TO_PROJECT,
+          ENABLE_BAZEL_IGNORE,
           BLAZE_BINARY_PATH,
           BAZEL_BINARY_PATH);
 
@@ -167,6 +174,7 @@ public class BlazeUserSettingsConfigurable extends AutoConfigurable {
             COLLAPSE_PROJECT_VIEW,
             FORMAT_BUILD_FILES_ON_SAVE,
             SHOW_ADD_FILE_TO_PROJECT,
+            ENABLE_BAZEL_IGNORE,
             BLAZE_BINARY_PATH,
             BAZEL_BINARY_PATH));
   }

--- a/base/src/com/google/idea/blaze/base/settings/ui/BlazeUserSettingsConfigurable.java
+++ b/base/src/com/google/idea/blaze/base/settings/ui/BlazeUserSettingsConfigurable.java
@@ -121,6 +121,12 @@ public class BlazeUserSettingsConfigurable extends AutoConfigurable {
                   .setter(BlazeUserSettings::setEnableBazelIgnore)
                   .componentFactory(SimpleComponent::createCheckBox);
 
+  public static final ConfigurableSetting<?, ?> SHOW_ROOT_FILES =
+          setting("With multiple entries . exludes workspace root directories")
+                  .getter(BlazeUserSettings::getShowRootFiles)
+                  .setter(BlazeUserSettings::setShowRootFiles)
+                  .componentFactory(SimpleComponent::createCheckBox);
+
   private static final String BLAZE_BINARY_PATH_KEY = "blaze.binary.path";
   private static final ConfigurableSetting<?, ?> BLAZE_BINARY_PATH =
       setting("Blaze binary location")
@@ -147,6 +153,7 @@ public class BlazeUserSettingsConfigurable extends AutoConfigurable {
           FORMAT_BUILD_FILES_ON_SAVE,
           SHOW_ADD_FILE_TO_PROJECT,
           ENABLE_BAZEL_IGNORE,
+          SHOW_ROOT_FILES,
           BLAZE_BINARY_PATH,
           BAZEL_BINARY_PATH);
 
@@ -175,6 +182,7 @@ public class BlazeUserSettingsConfigurable extends AutoConfigurable {
             FORMAT_BUILD_FILES_ON_SAVE,
             SHOW_ADD_FILE_TO_PROJECT,
             ENABLE_BAZEL_IGNORE,
+            SHOW_ROOT_FILES,
             BLAZE_BINARY_PATH,
             BAZEL_BINARY_PATH));
   }

--- a/base/tests/unittests/com/google/idea/blaze/base/projectview/ProjectViewVerifierTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/projectview/ProjectViewVerifierTest.java
@@ -30,6 +30,7 @@ import com.google.idea.blaze.base.projectview.section.sections.DirectorySection;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.ErrorCollector;
 import com.google.idea.blaze.base.scope.output.IssueOutput;
+import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.blaze.base.settings.BuildSystem;
 import com.google.idea.blaze.base.sync.BlazeSyncPlugin;
 import com.google.idea.blaze.base.sync.projectview.ImportRoots;
@@ -43,6 +44,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import static org.mockito.Mockito.mock;
 
 /** Tests for ProjectViewVerifier */
 @RunWith(JUnit4.class)
@@ -79,6 +82,7 @@ public class ProjectViewVerifierTest extends BlazeTestCase {
 
     fileOperationProvider = new MockFileOperationProvider(workspaceRoot);
     applicationServices.register(FileOperationProvider.class, fileOperationProvider);
+    applicationServices.register(BlazeUserSettings.class, mock(BlazeUserSettings.class));
     context = new BlazeContext();
     context.addOutputSink(IssueOutput.class, errorCollector);
   }

--- a/base/tests/unittests/com/google/idea/blaze/base/sync/BuildTargetFinderTest.java
+++ b/base/tests/unittests/com/google/idea/blaze/base/sync/BuildTargetFinderTest.java
@@ -30,6 +30,7 @@ import com.google.idea.blaze.base.model.primitives.WorkspacePath;
 import com.google.idea.blaze.base.model.primitives.WorkspaceRoot;
 import com.google.idea.blaze.base.projectview.section.sections.DirectoryEntry;
 import com.google.idea.blaze.base.settings.BlazeImportSettingsManager;
+import com.google.idea.blaze.base.settings.BlazeUserSettings;
 import com.google.idea.blaze.base.settings.BuildSystem;
 import com.google.idea.blaze.base.sync.projectview.ImportRoots;
 import com.google.idea.common.experiments.ExperimentService;
@@ -78,6 +79,7 @@ public class BuildTargetFinderTest extends BlazeTestCase {
     ExtensionPoint<BuildSystemProvider> extensionPoint =
         registerExtensionPoint(BuildSystemProvider.EP_NAME, BuildSystemProvider.class);
     extensionPoint.registerExtension(new BazelBuildSystemProvider());
+    applicationServices.register(BlazeUserSettings.class, mock(BlazeUserSettings.class));
   }
 
   private BuildTargetFinder buildTargetFinder(Collection<WorkspacePath> roots) {

--- a/java/tests/unittests/com/google/idea/blaze/java/sync/importer/BlazeJavaWorkspaceImporterTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/sync/importer/BlazeJavaWorkspaceImporterTest.java
@@ -17,6 +17,7 @@ package com.google.idea.blaze.java.sync.importer;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -58,10 +59,7 @@ import com.google.idea.blaze.base.projectview.section.sections.TestSourceSection
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.ErrorCollector;
 import com.google.idea.blaze.base.scope.output.IssueOutput;
-import com.google.idea.blaze.base.settings.Blaze;
-import com.google.idea.blaze.base.settings.BlazeImportSettings;
-import com.google.idea.blaze.base.settings.BlazeImportSettingsManager;
-import com.google.idea.blaze.base.settings.BuildSystem;
+import com.google.idea.blaze.base.settings.*;
 import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
 import com.google.idea.blaze.base.sync.workspace.ArtifactLocationDecoder;
 import com.google.idea.blaze.base.sync.workspace.MockArtifactLocationDecoder;
@@ -153,6 +151,7 @@ public class BlazeJavaWorkspaceImporterTest extends BlazeTestCase {
         });
     applicationServices.register(PackageManifestReader.class, new PackageManifestReader());
     applicationServices.register(PrefetchService.class, new MockPrefetchService());
+    applicationServices.register(BlazeUserSettings.class, mock(BlazeUserSettings.class));
 
     context = new BlazeContext();
     context.addOutputSink(IssueOutput.class, errorCollector);

--- a/scala/tests/unittests/com/google/idea/blaze/scala/sync/importer/BlazeScalaWorkspaceImporterTest.java
+++ b/scala/tests/unittests/com/google/idea/blaze/scala/sync/importer/BlazeScalaWorkspaceImporterTest.java
@@ -16,6 +16,7 @@
 package com.google.idea.blaze.scala.sync.importer;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -44,10 +45,7 @@ import com.google.idea.blaze.base.projectview.section.sections.DirectorySection;
 import com.google.idea.blaze.base.scope.BlazeContext;
 import com.google.idea.blaze.base.scope.ErrorCollector;
 import com.google.idea.blaze.base.scope.output.IssueOutput;
-import com.google.idea.blaze.base.settings.Blaze;
-import com.google.idea.blaze.base.settings.BlazeImportSettings;
-import com.google.idea.blaze.base.settings.BlazeImportSettingsManager;
-import com.google.idea.blaze.base.settings.BuildSystem;
+import com.google.idea.blaze.base.settings.*;
 import com.google.idea.blaze.base.sync.projectview.WorkspaceLanguageSettings;
 import com.google.idea.blaze.base.sync.workspace.ArtifactLocationDecoder;
 import com.google.idea.blaze.base.sync.workspace.MockArtifactLocationDecoder;
@@ -111,6 +109,7 @@ public class BlazeScalaWorkspaceImporterTest extends BlazeTestCase {
     applicationServices.register(PrefetchService.class, new MockPrefetchService());
     applicationServices.register(PackageManifestReader.class, new PackageManifestReader());
     applicationServices.register(ExperimentService.class, new MockExperimentService());
+    applicationServices.register(BlazeUserSettings.class, mock(BlazeUserSettings.class));
 
     // will silently fall back to FilePathJavaPackageReader
     applicationServices.register(


### PR DESCRIPTION
pls let me know WDYT

So, with this commit you don't need to specify `test_sources` explicitly in projectview. Idea will be able to figure out that you have test sources if you have rules which ends with `_test` in your project. This is important for two reasons:
1. You can mix in a single directory test sources and production source (I saw that some backend developers do this with bazel)
2. You will have  two more scopes in search window - `Project production files` and `Project test files`.  Scopes will work for full text search and `find usages`

I will be able to add tests if you agree with solution that I provided. 

by oleksandrr@wix.com