### PR TITLE
Arbitrary deployable JAR task should not upload local results to remote cache

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
+++ b/base/src/com/google/idea/blaze/base/command/BlazeFlags.java
@@ -52,6 +52,8 @@ public final class BlazeFlags {
 
   public static final String DELETED_PACKAGES = "--deleted_packages";
 
+  public static final String DISABLE_REMOTE_UPLOAD_LOCAL_RESULTS = "--remote_upload_local_results=false";
+
   /**
    * Flags to add to blaze/bazel invocations of the given type.
    *

--- a/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
+++ b/scala/src/com/google/idea/blaze/scala/run/producers/GenerateDeployableJarTaskProvider.java
@@ -235,6 +235,7 @@ class GenerateDeployableJarTaskProvider
                             BlazeFlags.blazeFlags(
                                 project, projectViewSet, BlazeCommandName.BUILD, invocationContext))
                         .addBlazeFlags(buildResultHelper.getBuildFlags())
+                        .addBlazeFlags(BlazeFlags.DISABLE_REMOTE_UPLOAD_LOCAL_RESULTS)
                         .build();
                 int exitCode =
                     ExternalTask.builder(workspaceRoot)


### PR DESCRIPTION
Added `--remote_upload_local_results=false` on `GenerateDeployableJarTaskProvider`