### PR TITLE
only filters labels according to parent packages for LanguageClass.C

### DIFF
--- a/base/src/com/google/idea/blaze/base/actions/BuildFileUtils.java
+++ b/base/src/com/google/idea/blaze/base/actions/BuildFileUtils.java
@@ -82,7 +82,6 @@ final class BuildFileUtils {
 
     Label label =
         filterCRelatedLabelsWhichBelongToOtherPackages(file,packagePath, targetLabels)
-            .filter(l -> l.blazePackage().equals(packagePath))
             .findFirst()
             .orElse(null);
     if (label == null) {

--- a/base/src/com/google/idea/blaze/base/actions/BuildFileUtils.java
+++ b/base/src/com/google/idea/blaze/base/actions/BuildFileUtils.java
@@ -80,11 +80,8 @@ final class BuildFileUtils {
     final Stream<Label> targetLabels = SourceToTargetMap.getInstance(project)
         .getTargetsToBuildForSourceFile(file).stream();
 
-    final Stream<Label> maybeFilteredLabels = filterCRelatedLabelsWhichBelongToOtherPackages(file,
-        packagePath, targetLabels);
-
     Label label =
-        maybeFilteredLabels
+        filterCRelatedLabelsWhichBelongToOtherPackages(file,packagePath, targetLabels)
             .filter(l -> l.blazePackage().equals(packagePath))
             .findFirst()
             .orElse(null);


### PR DESCRIPTION
This is to keep supporting CPP need while also supporting aggregate targets
More info:
https://bazelbuild.slack.com/archives/CM8JQCANN/p1566481600003600

> Filter was deliberately added to fix an issue with C++ headers.
> The original bug was that opening the BUILD file for foo/bar.h caused it to open baz/qux/BUILD because there’s a cc_library target in baz/qux that includes foo/bar.h in its headers. The source-to-target look up queries the index for the target during the last sync which compiled the source file. In this case, it was the cc_library target in baz/qux.
> So the fix was to ensure that the BUILD file is always for the parent package (foo/bar).

OTOH what we have with aggregate targets is that `Open Corresponding BUILD File` action, `Copy BUILD Target String`, and some custom dependency lookups don't work (for AutoDep we copied part of the implementation of  `findBuildTarget` to work around it).

Example for aggregate target:
```
a
    b
        BUILD.bazel (java_library with srcs pointing to filegroup from c & d)
        c
          BUILD.bazel (filegroup with glob)
          C.java
        d
          BUILD.bazel (filegroup with glob)
          D.java
```

1. I tried adding a test for this change but there are no tests for `findBuildTarget` at all let alone for the CPP fix. This made me question whether I want to dive into it. My current stand is to add it as is but I also considered covering existing behavior first. Problem is that it's likely a significant investment on this change and they might fix it differently at the end (see slack https://bazelbuild.slack.com/archives/CM8JQCANN/p1566576477000600?thread_ts=1566481600.003600&cid=CM8JQCANN https://bazelbuild.slack.com/archives/CM8JQCANN/p1566576507000800?thread_ts=1566481600.003600&cid=CM8JQCANN). Reason I'm not doing the suggested fix there is that it's much more complicated without fully diving into the code at `SourceToTargetMapImpl` (which I haven't done).

@ZachiNachshon @liucijus would appreciate your thoughts (more on the issues mentioned above than the really small code change)