### PR TITLE
sync works even with compilation problems

### DIFF
--- a/base/src/com/google/idea/blaze/base/sync/BlazeBuildParams.java
+++ b/base/src/com/google/idea/blaze/base/sync/BlazeBuildParams.java
@@ -36,12 +36,17 @@ public abstract class BlazeBuildParams {
         .setBlazeBinaryPath(provider.getSyncBinaryPath(project))
         .setBlazeBinaryType(binaryType)
         .setParallelizeBuilds(parallelizeRemoteSyncs.getValue() && binaryType.isRemote)
+        .setInfoOnly(false)
         .build();
   }
 
   public abstract String blazeBinaryPath();
 
   public abstract BuildBinaryType blazeBinaryType();
+
+  public abstract boolean infoOnly();
+
+  public abstract Builder toBuilder();
 
   /**
    * Whether batched build invocations are run in parallel, when possible (only when building
@@ -60,6 +65,8 @@ public abstract class BlazeBuildParams {
     public abstract Builder setBlazeBinaryPath(String value);
 
     public abstract Builder setBlazeBinaryType(BuildBinaryType value);
+
+    public abstract Builder setInfoOnly(boolean value);
 
     // not public; derived from BuildBinaryType
     abstract Builder setParallelizeBuilds(boolean parallelizeBuilds);

--- a/base/src/com/google/idea/blaze/base/sync/SyncPhaseCoordinator.java
+++ b/base/src/com/google/idea/blaze/base/sync/SyncPhaseCoordinator.java
@@ -362,6 +362,10 @@ final class SyncPhaseCoordinator {
           projectState != null
               ? BuildPhaseSyncTask.runBuildPhase(project, params, projectState, buildId, context)
               : BlazeSyncBuildResult.builder().build();
+      //If we have partial success we'll run the build again this time only with intellij-info-java
+      if (projectState != null && syncResultFromBuildPhase(buildResult, context) == SyncResult.PARTIAL_SUCCESS) {
+        buildResult = syncInfoOnly(params, context, buildId, projectState, buildResult);
+      }
       UpdatePhaseTask task =
           UpdatePhaseTask.builder()
               .setStartTime(startTime)
@@ -387,6 +391,25 @@ final class SyncPhaseCoordinator {
           SyncResult.FAILURE,
           SyncStats.builder());
     }
+  }
+
+  private BlazeSyncBuildResult syncInfoOnly(BlazeSyncParams params, BlazeContext context,
+      int buildId, SyncProjectState projectState, BlazeSyncBuildResult buildResult) {
+    final BlazeSyncParams infoOnlySyncParams = params.toBuilder().setBlazeBuildParams(
+        params.blazeBuildParams().toBuilder().setInfoOnly(true).build()
+    ).build();
+    final BlazeSyncBuildResult infoOnlySyncResult = BuildPhaseSyncTask
+        .runBuildPhase(project, infoOnlySyncParams, projectState, buildId, context);
+    /*
+     * updateResult should be used the other way around [ olderRun.updateResult(newerRun) ]
+     * since that is used to remove stale/old artifacts from targets which boths runs "saw"
+     * In our case both runs are sequential without artifacts changing.
+     * The second run only has IDE-INFO files
+     * For every target the first run was able to process it has all the data (first run does IDE-INFO and Resolve)
+     * What happens when we updateResult as below is that we basically just add the IDE-INFO files
+     * of the broken targets from the second run into the first run
+     */
+    return infoOnlySyncResult.updateResult(buildResult);
   }
 
   private void queueUpdateTask(UpdatePhaseTask task) {

--- a/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
+++ b/base/src/com/google/idea/blaze/base/sync/aspects/BlazeIdeInterfaceAspectsImpl.java
@@ -373,7 +373,9 @@ public class BlazeIdeInterfaceAspectsImpl implements BlazeIdeInterface {
 
       aspectStrategy.addAspectAndOutputGroups(
           builder,
-          ImmutableList.of(OutputGroup.INFO, OutputGroup.RESOLVE),
+          buildParams.infoOnly() ?
+            ImmutableList.of(OutputGroup.INFO):
+            ImmutableList.of(OutputGroup.INFO, OutputGroup.RESOLVE),
           activeLanguages,
           onlyDirectDeps);
 


### PR DESCRIPTION
if partial success (compilation issue) we issue another bazel build with info only

This is to make sure we have the needed metadata even if build broke
Relates to:
https://github.com/bazelbuild/intellij/issues/1167
https://github.com/bazelbuild/bazel/issues/9413

I don't like passing a boolean 5 level down but OTOH I couldn't find a closer way to interfere.
I thought about adding the option to override the output groups from above but that's still pretty messy with the levels and also the top level doesn't know about the exact syntax of ide-info resolve etc so I'm not sure adding the strings there is better.
Would love your thoughts.

@liucijus  @ZachiNachshon