### PR TITLE
derive_targets_from_directories now defaults to false on project import

### DIFF
--- a/base/src/com/google/idea/blaze/base/projectview/section/sections/AutomaticallyDeriveTargetsSection.java
+++ b/base/src/com/google/idea/blaze/base/projectview/section/sections/AutomaticallyDeriveTargetsSection.java
@@ -83,7 +83,7 @@ public class AutomaticallyDeriveTargetsSection {
                   TextBlock.of(
                       "# Automatically includes all relevant targets under the 'directories'"
                           + " above")))
-          .add(ScalarSection.builder(KEY).set(true))
+          .add(ScalarSection.builder(KEY).set(false))
           .add(TextBlockSection.of(TextBlock.newLine()))
           .build();
     }


### PR DESCRIPTION
to save all the errors users have until they find it out