### PR TITLE
jar cache defaults to on

### DIFF
--- a/java/src/com/google/idea/blaze/java/settings/BlazeJavaUserSettings.java
+++ b/java/src/com/google/idea/blaze/java/settings/BlazeJavaUserSettings.java
@@ -35,7 +35,7 @@ public class BlazeJavaUserSettings implements PersistentStateComponent<BlazeJava
   }
 
   private static boolean getDefaultJarCacheValue() {
-    return BuildSystemProvider.defaultBuildSystem().buildSystem() == BuildSystem.Blaze;
+    return true;
   }
 
   @Override


### PR DESCRIPTION
to save from users who don't follow the manual very well