### PR TITLE
Fix JavaLanguageLevelHelper.getJavaLanguageLevel api changes in upstream

### DIFF
--- a/plugin_dev/src/com/google/idea/blaze/plugin/sync/IntellijScalaPluginSyncPlugin.java
+++ b/plugin_dev/src/com/google/idea/blaze/plugin/sync/IntellijScalaPluginSyncPlugin.java
@@ -91,7 +91,7 @@ public class IntellijScalaPluginSyncPlugin implements BlazeSyncPlugin {
 
     LanguageLevel javaLanguageLevel =
         JavaLanguageLevelHelper.getJavaLanguageLevel(
-            projectViewSet, blazeProjectData, LanguageLevel.JDK_1_8);
+            projectViewSet, blazeProjectData);
 
     // Leave the SDK, but set the language level
     Transactions.submitWriteActionTransactionAndWait(


### PR DESCRIPTION
Default version is controlled by `java.defaultLanguageLevel.java11.enabled` experiment which by default is false. So default is `jdk-1.8`