### PR TITLE
Expose ProtoIdeInfo for proto_library during sync

### DIFF
--- a/aspect/intellij_info_impl.bzl
+++ b/aspect/intellij_info_impl.bzl
@@ -319,6 +319,24 @@ def _do_starlark_string_expansion(ctx, name, strings, extra_targets = []):
     return strings
 
 ##### Builders for individual parts of the aspect output
+def collect_proto_info(target, ctx, semantics, ide_info, ide_info_file, output_groups):
+    if not ProtoInfo in target:
+        return False
+
+    proto_info = target[ProtoInfo]
+    proto_output = depset([proto_info.direct_descriptor_set])
+
+    ide_info["proto_ide_info"] = struct_omit_none(
+        sources = sources_from_target(ctx),
+        source_root = proto_info.proto_source_root,
+        strip_import_prefix = ctx.rule.attr.strip_import_prefix,
+        import_prefix = ctx.rule.attr.import_prefix,
+    )
+
+    update_sync_output_groups(output_groups, "intellij-info-proto", depset([ide_info_file]))
+    update_sync_output_groups(output_groups, "intellij-compile-proto", proto_output)
+    update_sync_output_groups(output_groups, "intellij-resolve-proto", proto_output)
+    return True
 
 def collect_py_info(target, ctx, semantics, ide_info, ide_info_file, output_groups):
     """Updates Python-specific output groups, returns false if not a Python target."""
@@ -1105,6 +1123,7 @@ def intellij_info_aspect_impl(target, ctx, semantics):
     ide_info["test_info"] = build_test_info(ctx)
 
     handled = False
+    handled = collect_proto_info(target, ctx, semantics, ide_info, ide_info_file, output_groups) or handled
     handled = collect_py_info(target, ctx, semantics, ide_info, ide_info_file, output_groups) or handled
     handled = collect_cpp_info(target, ctx, semantics, ide_info, ide_info_file, output_groups) or handled
     handled = collect_c_toolchain_info(target, ctx, semantics, ide_info, ide_info_file, output_groups) or handled

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/pl/BUILD
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/pl/BUILD
@@ -1,0 +1,41 @@
+licenses(["notice"])  # Apache 2.0
+
+load(
+    "//aspect/testing/rules:intellij_aspect_test_fixture.bzl",
+    "intellij_aspect_test_fixture",
+)
+
+proto_library(
+    name = "a_proto",
+    srcs = ["a.proto"],
+    import_prefix = "test",
+    strip_import_prefix = "/" + package_name(),
+)
+
+proto_library(
+    name = "b_proto",
+    srcs = ["b.proto"],
+    deps = [":a_proto"],
+)
+
+intellij_aspect_test_fixture(
+    name = "fixture",
+    deps = [":b_proto"],
+)
+
+java_test(
+    name = "ProtoLibraryTest",
+    srcs = ["ProtoLibraryTest.java"],
+    data = [
+        ":fixture",
+    ],
+    deps = [
+        "//aspect/testing:BazelIntellijAspectTest",
+        "//aspect/testing:guava",
+        "//aspect/testing/rules:IntellijAspectTest",
+        "//aspect/testing/rules:intellij_aspect_test_fixture_java_proto",
+        "//intellij_platform_sdk:test_libs",
+        "//proto:intellij_ide_info_java_proto",
+        "@junit//jar",
+    ],
+)

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/pl/ProtoLibraryTest.java
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/pl/ProtoLibraryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.aspect.proto.pl;
+
+import com.google.devtools.intellij.IntellijAspectTestFixtureOuterClass.IntellijAspectTestFixture;
+import com.google.devtools.intellij.ideinfo.IntellijIdeInfo.TargetIdeInfo;
+import com.google.idea.blaze.BazelIntellijAspectTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/** Tests for proto_library. */
+@RunWith(JUnit4.class)
+public class ProtoLibraryTest extends BazelIntellijAspectTest {
+
+  @Test
+  public void testProtoLibrary() throws Exception {
+    IntellijAspectTestFixture fixture = loadTestFixture(":fixture");
+
+    TargetIdeInfo aProto = findTarget(fixture, ":a_proto");
+    assertThat(aProto).isNotNull();
+    assertThat(aProto.hasProtoIdeInfo()).isTrue();
+    assertThat(relativePathsForArtifacts(aProto.getProtoIdeInfo().getSourcesList()))
+        .containsExactly(testRelative("a.proto"));
+    assertThat(aProto.getProtoIdeInfo().getSourceRoot())
+        .isEqualTo(
+            "bazel-out/darwin-fastbuild/bin/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/pl/_virtual_imports/a_proto");
+    assertThat(aProto.getProtoIdeInfo().getImportPrefix()).isEqualTo("test");
+    assertThat(aProto.getProtoIdeInfo().getStripImportPrefix())
+        .isEqualTo("/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/pl");
+
+    TargetIdeInfo bProto = findTarget(fixture, ":b_proto");
+    assertThat(bProto).isNotNull();
+    assertThat(bProto.hasProtoIdeInfo()).isTrue();
+    assertThat(relativePathsForArtifacts(bProto.getProtoIdeInfo().getSourcesList()))
+        .containsExactly(testRelative("b.proto"));
+    assertThat(bProto.getProtoIdeInfo().getSourceRoot()).isEqualTo(".");
+    assertThat(bProto.getProtoIdeInfo().getImportPrefix()).isEmpty();
+    assertThat(bProto.getProtoIdeInfo().getStripImportPrefix()).isEmpty();
+    assertThat(dependenciesForTarget(bProto)).contains(dep(aProto));
+
+    assertThat(getOutputGroupFiles(fixture, "intellij-info-proto"))
+        .containsExactly(
+            testRelative(intellijInfoFileName(aProto.getKey())),
+            testRelative(intellijInfoFileName(bProto.getKey())));
+
+    assertThat(getOutputGroupFiles(fixture, "intellij-compile-proto"))
+        .containsExactly(
+            testRelative("a_proto-descriptor-set.proto.bin"),
+            testRelative("b_proto-descriptor-set.proto.bin"));
+
+    assertThat(getOutputGroupFiles(fixture, "intellij-resolve-proto"))
+        .containsExactly(
+            testRelative("a_proto-descriptor-set.proto.bin"),
+            testRelative("b_proto-descriptor-set.proto.bin"));
+  }
+}

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/pl/a.proto
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/pl/a.proto
@@ -1,0 +1,3 @@
+syntax = "proto2";
+package a;
+message A {}

--- a/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/pl/b.proto
+++ b/aspect/testing/tests/src/com/google/idea/blaze/aspect/proto/pl/b.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+import "test/a.proto";
+package b;
+message B {a.A a = 1;}

--- a/base/src/com/google/idea/blaze/base/ideinfo/ProtoIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/ProtoIdeInfo.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2016 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.idea.blaze.base.ideinfo;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.devtools.intellij.ideinfo.IntellijIdeInfo;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/** Ide info specific to proto rules. */
+public final class ProtoIdeInfo implements ProtoWrapper<IntellijIdeInfo.ProtoIdeInfo> {
+  private final ImmutableList<ArtifactLocation> sources;
+  @Nullable private final String sourceRoot;
+  @Nullable private final String importPrefix;
+  @Nullable private final String stripImportPrefix;
+
+  private ProtoIdeInfo(
+      ImmutableList<ArtifactLocation> sources,
+      @Nullable String sourceRoot,
+      @Nullable String importPrefix,
+      @Nullable String stripImportPrefix) {
+    this.sources = sources;
+    this.sourceRoot = sourceRoot;
+    this.importPrefix = importPrefix;
+    this.stripImportPrefix = stripImportPrefix;
+  }
+
+  static ProtoIdeInfo fromProto(IntellijIdeInfo.ProtoIdeInfo proto) {
+    return new ProtoIdeInfo(
+        ProtoWrapper.map(proto.getSourcesList(), ArtifactLocation::fromProto),
+        Strings.emptyToNull(proto.getSourceRoot()),
+        Strings.emptyToNull(proto.getImportPrefix()),
+        Strings.emptyToNull(proto.getStripImportPrefix()));
+  }
+
+  @Override
+  public IntellijIdeInfo.ProtoIdeInfo toProto() {
+    IntellijIdeInfo.ProtoIdeInfo.Builder builder =
+        IntellijIdeInfo.ProtoIdeInfo.newBuilder().addAllSources(ProtoWrapper.mapToProtos(sources));
+    ProtoWrapper.setIfNotNull(builder::setSourceRoot, sourceRoot);
+    ProtoWrapper.setIfNotNull(builder::setImportPrefix, importPrefix);
+    ProtoWrapper.setIfNotNull(builder::setStripImportPrefix, stripImportPrefix);
+    return builder.build();
+  }
+
+  public ImmutableList<ArtifactLocation> getSources() {
+    return sources;
+  }
+
+  @Nullable
+  public String getSourceRoot() {
+    return sourceRoot;
+  }
+
+  @Nullable
+  public String getImportPrefix() {
+    return importPrefix;
+  }
+
+  @Nullable
+  public String getStripImportPrefix() {
+    return stripImportPrefix;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Builder for proto info */
+  public static class Builder {
+    @Nullable String sourceRoot;
+    @Nullable String importPrefix;
+    @Nullable String stripImportPrefix;
+
+    public Builder setSourceRoot(String sourceRoot) {
+      this.sourceRoot = sourceRoot;
+      return this;
+    }
+
+    public Builder setImportPrefix(String importPrefix) {
+      this.importPrefix = importPrefix;
+      return this;
+    }
+
+    public Builder setStripImportPrefix(String stripImportPrefix) {
+      this.stripImportPrefix = stripImportPrefix;
+      return this;
+    }
+
+    public ProtoIdeInfo build() {
+      return new ProtoIdeInfo(ImmutableList.of(), sourceRoot, importPrefix, stripImportPrefix);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ProtoIdeInfo that = (ProtoIdeInfo) o;
+    return Objects.equals(sources, that.sources)
+        && Objects.equals(sourceRoot, that.sourceRoot)
+        && Objects.equals(importPrefix, that.importPrefix)
+        && Objects.equals(stripImportPrefix, that.stripImportPrefix);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sources, sourceRoot, importPrefix, stripImportPrefix);
+  }
+}

--- a/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
+++ b/base/src/com/google/idea/blaze/base/ideinfo/TargetIdeInfo.java
@@ -53,6 +53,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
   @Nullable private final TestIdeInfo testIdeInfo;
   @Nullable private final JavaToolchainIdeInfo javaToolchainIdeInfo;
   @Nullable private final KotlinToolchainIdeInfo kotlinToolchainIdeInfo;
+  @Nullable private final ProtoIdeInfo protoIdeInfo;
   @Nullable private final Long syncTimeMillis;
 
   private TargetIdeInfo(
@@ -77,6 +78,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
       @Nullable TestIdeInfo testIdeInfo,
       @Nullable JavaToolchainIdeInfo javaToolchainIdeInfo,
       @Nullable KotlinToolchainIdeInfo kotlinToolchainIdeInfo,
+      @Nullable ProtoIdeInfo protoIdeInfo,
       @Nullable Long syncTimeMillis) {
     this.key = key;
     this.kind = kind;
@@ -99,6 +101,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
     this.testIdeInfo = testIdeInfo;
     this.javaToolchainIdeInfo = javaToolchainIdeInfo;
     this.kotlinToolchainIdeInfo = kotlinToolchainIdeInfo;
+    this.protoIdeInfo = protoIdeInfo;
     this.syncTimeMillis = syncTimeMillis;
   }
 
@@ -154,6 +157,11 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
       dartIdeInfo = DartIdeInfo.fromProto(proto.getDartIdeInfo());
       sourcesBuilder.addAll(dartIdeInfo.getSources());
     }
+    ProtoIdeInfo protoIdeInfo = null;
+    if (proto.hasProtoIdeInfo()) {
+      protoIdeInfo = ProtoIdeInfo.fromProto(proto.getProtoIdeInfo());
+      sourcesBuilder.addAll(protoIdeInfo.getSources());
+    }
     Long syncTime =
         syncTimeOverride != null
             ? Long.valueOf(syncTimeOverride.toEpochMilli())
@@ -194,6 +202,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
         proto.hasKtToolchainIdeInfo()
             ? KotlinToolchainIdeInfo.fromProto(proto.getKtToolchainIdeInfo())
             : null,
+        protoIdeInfo,
         syncTime);
   }
 
@@ -222,6 +231,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setTestInfo, testIdeInfo);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setJavaToolchainIdeInfo, javaToolchainIdeInfo);
     ProtoWrapper.unwrapAndSetIfNotNull(builder::setKtToolchainIdeInfo, kotlinToolchainIdeInfo);
+    ProtoWrapper.unwrapAndSetIfNotNull(builder::setProtoIdeInfo, protoIdeInfo);
     ProtoWrapper.setIfNotNull(builder::setSyncTimeMillis, syncTimeMillis);
     return builder.build();
   }
@@ -257,6 +267,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
         testIdeInfo,
         javaToolchainIdeInfo,
         kotlinToolchainIdeInfo,
+        protoIdeInfo,
         syncTimeMillis);
   }
 
@@ -361,6 +372,11 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
   }
 
   @Nullable
+  public ProtoIdeInfo getProtoIdeInfo() {
+    return protoIdeInfo;
+  }
+
+  @Nullable
   public Instant getSyncTime() {
     return syncTimeMillis != null ? Instant.ofEpochMilli(syncTimeMillis) : null;
   }
@@ -418,6 +434,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
     private TestIdeInfo testIdeInfo;
     private JavaToolchainIdeInfo javaToolchainIdeInfo;
     private KotlinToolchainIdeInfo kotlinToolchainIdeInfo;
+    private ProtoIdeInfo protoIdeInfo;
     private Long syncTime;
 
     public Builder setLabel(String label) {
@@ -527,6 +544,11 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
       return this;
     }
 
+    public Builder setProtoInfo(ProtoIdeInfo.Builder builder) {
+      protoIdeInfo = builder.build();
+      return this;
+    }
+
     public Builder addTag(String s) {
       this.tags.add(s);
       return this;
@@ -580,6 +602,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
           testIdeInfo,
           javaToolchainIdeInfo,
           kotlinToolchainIdeInfo,
+          protoIdeInfo,
           syncTime);
     }
   }
@@ -614,6 +637,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
         && Objects.equals(testIdeInfo, that.testIdeInfo)
         && Objects.equals(javaToolchainIdeInfo, that.javaToolchainIdeInfo)
         && Objects.equals(kotlinToolchainIdeInfo, that.kotlinToolchainIdeInfo)
+        && Objects.equals(protoIdeInfo, that.protoIdeInfo)
         && Objects.equals(syncTimeMillis, that.syncTimeMillis);
   }
 
@@ -641,6 +665,7 @@ public final class TargetIdeInfo implements ProtoWrapper<IntellijIdeInfo.TargetI
         testIdeInfo,
         javaToolchainIdeInfo,
         kotlinToolchainIdeInfo,
+        protoIdeInfo,
         syncTimeMillis);
   }
 }

--- a/proto/intellij_ide_info.proto
+++ b/proto/intellij_ide_info.proto
@@ -205,6 +205,13 @@ message Dependency {
   DependencyType dependency_type = 2;
 }
 
+message ProtoIdeInfo {
+  repeated ArtifactLocation sources = 1;
+  string source_root = 2;
+  string import_prefix = 3;
+  string strip_import_prefix = 4;
+}
+
 message TargetIdeInfo {
   string kind_string = 1;
   TargetKey key = 2;
@@ -236,4 +243,5 @@ message TargetIdeInfo {
   TsIdeInfo ts_ide_info = 160;
   DartIdeInfo dart_ide_info = 170;
   KotlinToolchainIdeInfo kt_toolchain_ide_info = 180;
+  ProtoIdeInfo proto_ide_info = 190;
 }


### PR DESCRIPTION
`idea.plugin.protoeditor` needs to be aware of source roots of proto libraries. 

`ProtoIdeInfo` propagates few `proto_library` options to intellij:
* source files specified in `proto_library`'s `src` attribute (will help to map error locations to correct source file)
* sources root taken from `ProtoInfo.proto_source_root` (usually points to `_virtual_imports` with `strip_import_prefix` and `import_prefix` applied to import path)
* `strip_import_prefix` (will be used to map proto root in source tree ie avoid symlinks)
* `import_prefix`

Aspect registers three output groups:
* `intellij-info-proto` - builds `*-intellij-info.txt` with info specified above during sync
* `intellij-compile-proto` - builds `proto_library`'s binary output during `build` ie `*-descriptor-set.proto.bin`
* `intellij-resolve-proto` - builds same as `intellij-compile-proto` but during sync (will force generation of `_virtual_imports` needed for 2nd_party deps)