### PR TITLE
Fast test supports ITs

### DIFF
--- a/java/src/com/google/idea/blaze/java/run/fastbuild/FastBuildTestEnvironmentCreator.java
+++ b/java/src/com/google/idea/blaze/java/run/fastbuild/FastBuildTestEnvironmentCreator.java
@@ -142,12 +142,6 @@ abstract class FastBuildTestEnvironmentCreator implements BuildSystemExtensionPo
     addJvmOptsFromBlazeFlags(config, commandBuilder);
 
     for (String flag : targetJavaInfo.jvmFlags()) {
-      // Wix tooling injects some java arguments which makes java call fail
-      // Temporary filtering them out to see if it's makes run succeed
-      // ex: "-javaagent:$(rootpath @core_server_build_tools//test-agent/src/main/java/com/wixpress/agent:test-agent_deploy.jar)"
-      if (flag.contains("@core_server_build_tools")) {
-        continue;
-      }
       commandBuilder.addJvmArgument(
           LocationSubstitution.replaceLocations(flag, target, targetData.data()));
     }

--- a/java/src/com/google/idea/blaze/java/run/fastbuild/LocationSubstitution.java
+++ b/java/src/com/google/idea/blaze/java/run/fastbuild/LocationSubstitution.java
@@ -31,7 +31,7 @@ final class LocationSubstitution {
   //   \$\((locations?)\s+([^)]+)\s*\)
   // The first group is 'location' or 'locations'. The second group is the target.
   private static final Pattern LOCATION_PATTERN =
-      Pattern.compile("\\$\\((locations?)\\s+([^)]+)\\s*\\)");
+      Pattern.compile("\\$\\((locations?|rootpaths?)\\s+([^)]+)\\s*\\)");
 
   private LocationSubstitution() {}
 

--- a/java/tests/unittests/com/google/idea/blaze/java/run/fastbuild/LocationSubstitutionTest.java
+++ b/java/tests/unittests/com/google/idea/blaze/java/run/fastbuild/LocationSubstitutionTest.java
@@ -207,4 +207,34 @@ public class LocationSubstitutionTest {
       assertThat(e.getMessage()).contains(SOURCE_TARGET.toString());
     }
   }
+
+  @Test
+  public void testRootpathSubstitution() throws ExecutionException {
+    ImmutableMap<Label, ImmutableSet<ArtifactLocation>> data =
+        ImmutableMap.of(
+            Label.create("//test/location:location"),
+            ImmutableSet.of(
+                ArtifactLocation.builder().setRelativePath("test/location.txt").build()));
+
+    String result =
+        LocationSubstitution.replaceLocations(
+            "foo$(rootpath //test/location)bar", SOURCE_TARGET, data);
+
+    assertThat(result).isEqualTo("footest/location.txtbar");
+  }
+
+  @Test
+  public void testRootpathsWithSingleArtifact() throws ExecutionException {
+    ImmutableMap<Label, ImmutableSet<ArtifactLocation>> data =
+        ImmutableMap.of(
+            Label.create("//test/location:location"),
+            ImmutableSet.of(
+                ArtifactLocation.builder().setRelativePath("test/location.txt").build()));
+
+    String result =
+        LocationSubstitution.replaceLocations(
+            "foo$(rootpaths //test/location)bar", SOURCE_TARGET, data);
+
+    assertThat(result).isEqualTo("footest/location.txtbar");
+  }
 }


### PR DESCRIPTION
Location substituion supports runpath(s) in addition to location(s) Still includes a hack of the env variable of BUILD_TOOL which we need to see how to remove but at least a smaller hack than before