### PR TITLE
Fix wixperiments debugging

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/OutputArtifactParser.java
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/OutputArtifactParser.java
@@ -75,6 +75,8 @@ public interface OutputArtifactParser {
       BuildEventStreamProtos.File file, String configurationMnemonic) {
     List<String> pathPrefixList = file.getPathPrefixList();
     if (pathPrefixList.size() <= 1) {
+        if (file.getUri().contains("/external/"))
+            return file.getUri().substring(file.getUri().indexOf("/external/"));
       // fall back to using the configuration mnemonic
       // TODO(brendandouglas): remove this backwards compatibility code after September 2019
       return configurationMnemonic + "/" + file.getName();


### PR DESCRIPTION
Debugging wixperiments fails with
```
Error running 'Bazel build :wixperiments_dev'
Plugin file 'external/scala_2024_1/Scala/lib/bsp4j-2.1.0-M3.jar' not found. Did the build fail?
```

This happens at https://github.com/wix-playground/intellij/blob/wix-master/plugin_dev/src/com/google/idea/blaze/plugin/run/BlazeIntellijPluginDeployer.java#L189

It searches deploy file execution path (`external/scala_2024_1/Scala/lib/bsp4j-2.1.0-M3.jar`) within build artifacts relative paths which is `darwin_x86_64-fastbuild/Scala/lib/bsp4j-2.1.0-M3.jar` and cannot find it

Build artifact files are pupulated here https://github.com/wix-playground/intellij/blob/wix-master/base/src/com/google/idea/blaze/base/command/buildresult/OutputArtifactParser.java#L80

Add special treament for external files so deployer can find it.
