### PR TITLE
Fix: resource_strip_prefix for dependent projects

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -28,10 +28,7 @@ java_library(
 
 kt_jvm_library(
     name = "base",
-    srcs = glob([
-        "src/**/*.java",
-        "src/**/*.kt",
-    ]),
+    srcs = glob(["src/**/*.java", "src/**/*.kt"]),
     resource_jars = [":resources"],
     visibility = PLUGIN_PACKAGES_VISIBILITY,
     deps = [

--- a/base/BUILD
+++ b/base/BUILD
@@ -20,11 +20,19 @@ load(
 )
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
+java_library(
+    name = "resources",
+    resource_strip_prefix = package_name() + "/src",
+    resources = glob(["src/resources/**/*"]),
+)
+
 kt_jvm_library(
     name = "base",
-    srcs = glob(["src/**/*.java", "src/**/*.kt"]),
-    resources = glob(["src/resources/**/*"]),
-    resource_strip_prefix = "base/src",
+    srcs = glob([
+        "src/**/*.java",
+        "src/**/*.kt",
+    ]),
+    resource_jars = [":resources"],
     visibility = PLUGIN_PACKAGES_VISIBILITY,
     deps = [
         "//common/actions",


### PR DESCRIPTION
wixperiments fail to build because resource files doesn't start with a prefix when used as a source dependency