### PR TITLE
bep: merge outout groups that comes from aspect and rule

### DIFF
--- a/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.kt
+++ b/base/src/com/google/idea/blaze/base/command/buildresult/bepparser/BepParser.kt
@@ -142,10 +142,7 @@ private class OutputGroupTargetConfigFileSetMap {
   }
 
   fun setOutputGroupTargetConfig(outputGroup: String, target: String, config: String, fileSetNames: List<String>) {
-    val previous = getOutputGroupTarget(outputGroup, target).put(config, fileSetNames.toList())
-    if (previous != null) {
-      error("$outputGroup:$target:$config already present")
-    }
+    getOutputGroupTarget(outputGroup, target).merge(config, fileSetNames.toList(), { a, b -> a + b })
   }
 
   fun fileSetStream(): Sequence<OutputGroupTargetConfigFileSets> {


### PR DESCRIPTION
Probably this is a bad idea. According to:
- https://bazel.build/extending/aspects
- https://bazel.build/extending/rules#requesting_output_files

it's an error to return same output group from aspect and a rule.

Need to migrate `intellij-info-generic` usages outside of intellij